### PR TITLE
PR: Move statusbar widget to the right

### DIFF
--- a/requirements/conda_run.txt
+++ b/requirements/conda_run.txt
@@ -1,2 +1,2 @@
 QScreenCast
-spyder>=5
+spyder>=5.0.1

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(os.path.join(here, "README.md"), "r", encoding="utf-8") as f:
 
 install_requires = [
     'QScreenCast',
-    'spyder>=5',
+    'spyder>=5.0.1',
 ]
 
 setup(
@@ -36,7 +36,7 @@ setup(
         ],
     },
     # See: https://pypi.org/classifiers/
-    classifiers=[  
+    classifiers=[
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
         'Operating System :: MacOS :: MacOS X',
@@ -64,7 +64,7 @@ setup(
         'Topic :: Multimedia :: Video :: Capture',
     ],
     license="MIT",
-    keywords=[  
+    keywords=[
         'screencast',
         'qt',
     ],

--- a/spyder_screencast/plugin.py
+++ b/spyder_screencast/plugin.py
@@ -10,6 +10,7 @@ from qtpy.QtCore import QPoint, QSize, Signal
 from qtpy.QtGui import QIcon
 from spyder.api.plugins import SpyderPluginV2, Plugins
 from spyder.api.translations import get_translation
+from spyder.plugins.statusbar.plugin import StatusBarWidgetPosition
 
 # Local imports
 from spyder_screencast.container import ScreenCastContainer
@@ -58,7 +59,8 @@ class ScreenCast(SpyderPluginV2):
         container.sig_move_main_window_requested.connect(
             self.sig_move_main_window_requested)
 
-        status_bar.add_status_widget(container.status_widget)
+        status_bar.add_status_widget(
+            container.status_widget, position=StatusBarWidgetPosition.Right)
 
     def check_compatibility(self):
         valid = True


### PR DESCRIPTION
This PR includes the changes to set the status bar widget to the right,

![image](https://user-images.githubusercontent.com/20992645/115101975-cbf2a480-9f0d-11eb-9b64-a83133b49e4b.png)

Also it bumps Spyder version to the latest to ensure that the new API is available for the plugin.